### PR TITLE
add possibility to only show the native ios rate dialog

### DIFF
--- a/lib/src/core.dart
+++ b/lib/src/core.dart
@@ -92,6 +92,23 @@ class RateMyApp {
     return null;
   }
 
+  /// checks if the native rate dialog is available
+  ///
+  /// Only works for ios
+  Future<bool> canShowNativeIosRateDialog() {
+    assert(Platform.isIOS);
+    return _channel.invokeMethod('canRequestReview');
+  }
+
+  /// shows the native rate dialog
+  ///
+  /// Only works for ios
+  Future<void> showNativeIosRateDialog() {
+    assert(Platform.isIOS);
+    unawaited(callEvent(RateMyAppEventType.iOSRequestReview));
+    return _channel.invokeMethod('requestReview');
+  }
+
   /// Shows the rate dialog.
   Future<void> showRateDialog(
     BuildContext context, {
@@ -107,9 +124,8 @@ class RateMyApp {
     DialogStyle dialogStyle,
     VoidCallback onDismissed,
   }) async {
-    if (!ignoreIOS && Platform.isIOS && await _channel.invokeMethod('canRequestReview')) {
-      unawaited(callEvent(RateMyAppEventType.iOSRequestReview));
-      return _channel.invokeMethod('requestReview');
+    if (!ignoreIOS && Platform.isIOS && await canShowNativeIosRateDialog()) {
+      return showNativeIosRateDialog();
     }
 
     unawaited(callEvent(RateMyAppEventType.dialogOpen));
@@ -146,9 +162,8 @@ class RateMyApp {
     StarRatingOptions starRatingOptions,
     VoidCallback onDismissed,
   }) async {
-    if (!ignoreIOS && Platform.isIOS && await _channel.invokeMethod('canRequestReview')) {
-      unawaited(callEvent(RateMyAppEventType.iOSRequestReview));
-      return _channel.invokeMethod('requestReview');
+    if (!ignoreIOS && Platform.isIOS && await canShowNativeIosRateDialog()) {
+      return showNativeIosRateDialog();
     }
 
     assert(actionsBuilder != null);


### PR DESCRIPTION
### issue
currently it's not possible to only show the native ios rate dialog. This capability is needed because I want to have a custom action for android but still want to show the native ios rate dialog.

### changes
I added a method to
- check whether the native ios rate dialog is available
- shwo the native ios rate dialog