### PR TITLE
Added support for custom transitions

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -230,7 +230,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -265,7 +265,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
Hi, I'm the one who opened the issue yesterday. I went ahead and coded the custom transition support by myself. Please review it and merge. 

Fixes #100 

I changed the core.dart showDialog functions to showGeneralDialog functions. Also, I used an enum to give users a way to implement transitions easily. The enums contain some basic transitions and users can change them using some properties. When a user does not specify any transitions, it defaults to using the showDialog() function. This way the current users won't feel any difference in transitions. 

Furthermore, it has support to add user custom transition builders.

@Skyost 