### PR TITLE
Use adaptive alert dialogs

### DIFF
--- a/lib/src/dialogs.dart
+++ b/lib/src/dialogs.dart
@@ -81,7 +81,7 @@ class RateMyAppDialog extends StatelessWidget {
       ),
     );
 
-    return AlertDialog(
+    return AlertDialog.adaptive(
       title: Padding(
         padding: dialogStyle.titlePadding,
         child: Text(
@@ -205,7 +205,7 @@ class _RateMyAppStarDialogState extends State<RateMyAppStarDialog> {
       ),
     );
 
-    return AlertDialog(
+    return AlertDialog.adaptive(
       title: Padding(
         padding: widget.dialogStyle.titlePadding,
         child: Text(


### PR DESCRIPTION
Replaced usage of AlertDialog(...) with AlertDialog.adaptive(...)

AlertDialog.adaptive() automatically renders a CupertinoAlertDialog on iOS and a Material AlertDialog on Android.

This ensures a platform-consistent user experience with native look & feel.