### PR TITLE
[UPDATE] add custom border color for item checked

### DIFF
--- a/lib/src/dialogs.dart
+++ b/lib/src/dialogs.dart
@@ -273,7 +273,7 @@ class _RateMyAppStarDialogState extends State<RateMyAppStarDialog> {
                   ),
                   Icon(
                     Icons.star_border,
-                    color: widget.starRatingOptions.borderColor,
+                    color: widget.starRatingOptions.borderColorChecked,
                     size: widget.starRatingOptions.itemSize,
                   ),
                 ],

--- a/lib/src/style.dart
+++ b/lib/src/style.dart
@@ -83,6 +83,9 @@ class StarRatingOptions {
   /// Item Color
   final Color itemColor;
 
+  /// Border color of the item checked. Defaults to [itemColor]
+  final Color  borderColorChecked;
+
   /// Border color of the default Rating Widget. Defaults to [itemColor]
   final Color? borderColor;
 
@@ -115,6 +118,7 @@ class StarRatingOptions {
     this.itemSize = 40,
     this.itemCount = 5,
     this.itemColor = Colors.orangeAccent,
+    Color? borderColorChecked,
     this.borderColor,
     this.glow = false,
     this.glowRadius = 2,
@@ -122,7 +126,7 @@ class StarRatingOptions {
     this.direction = Axis.horizontal,
     this.tapOnlyMode = false,
     this.wrapAlignment = WrapAlignment.start,
-  });
+  }) : borderColorChecked = borderColorChecked ?? itemColor;
 }
 
 /// Allows to control dialogs transitions.


### PR DESCRIPTION
This pull request introduces a new customization option for the RateMyApp project by adding the ability to define a specific border color for checked items.

Main Changes:
New borderColorChecked Property:

File modified: lib/src/style.dart
A new property, borderColorChecked, has been added to the StarRatingOptions class.

If not explicitly set, this property defaults to the value of itemColor.
`final Color borderColorChecked;`

Constructor update:
`this.borderColorChecked = borderColorChecked ?? itemColor;`

Usage of borderColorChecked:
File modified: lib/src/dialogs.dart
The color of the border for the checked star icons now uses the borderColorChecked property instead of borderColor.
Example change:
`color: widget.starRatingOptions.borderColorChecked,`

Why this PR?
These changes allow for greater customization of the user interface by enabling the use of a distinct border color for selected stars, enhancing the visual design flexibility.